### PR TITLE
Fix broken command on Mac

### DIFF
--- a/examples/persistence-service-catalog.md
+++ b/examples/persistence-service-catalog.md
@@ -30,7 +30,7 @@ make install && sudo cp $GOPATH/bin/odo /usr/local/bin
 Alternatively you can install the latest odo release (requires you have [jq](https://stedolan.github.io/jq/) setup)
 
 ```bash
-curl -L -o odo $(curl -sL https://api.github.com/repos/redhat-developer/odo/releases/latest | jq -r '.assets[].browser_download_url' | grep 'odo-linux-amd64$') # use odo-darwin-64 for Mac
+curl -L -o odo $(curl -sL https://api.github.com/repos/redhat-developer/odo/releases/latest | jq -r '.assets[].browser_download_url' | grep 'odo-linux-amd64$') # use odo-darwin-amd64 for Mac
 chmod +x odo
 sudo cp odo /usr/local/bin
 ```


### PR DESCRIPTION
Fixes #73 

The full command for Mac is: `curl -L -o odo $(curl -sL https://api.github.com/repos/redhat-developer/odo/releases/latest | jq -r '.assets[].browser_download_url' | grep 'odo-darwin-amd64$')`